### PR TITLE
Fix timer when no JIT compilation is done

### DIFF
--- a/src/jax_hpc_profiler/timer.py
+++ b/src/jax_hpc_profiler/timer.py
@@ -25,8 +25,13 @@ class Timer:
     ):
         self.jit_time = 0.0
         self.times = []
-        self.profiling_data = {}
-        self.compiled_code = {}
+        self.profiling_data = {
+            'generated_code': 'N/A',
+            'argument_size': 'N/A',
+            'output_size': 'N/A',
+            'temp_size': 'N/A',
+        }
+        self.compiled_code = {'JAXPR': 'N/A', 'LOWERED': 'N/A', 'COMPILED': 'N/A'}
         self.save_jaxpr = save_jaxpr
         self.compile_info = compile_info
         self.jax_fn = jax_fn


### PR DESCRIPTION
This pull request updates the initialization of the `profiling_data` and `compiled_code` attributes in the `Timer` class to provide default values for their keys, ensuring that these dictionaries always contain expected fields even if no profiling or compilation has been performed yet.

- Initialization improvements:
  * The `profiling_data` dictionary now includes default keys (`generated_code`, `argument_size`, `output_size`, `temp_size`) with a value of `'N/A'`. (`[src/jax_hpc_profiler/timer.pyL28-R34](diffhunk://#diff-0034a65156be75f334a9acb96d556168ecbe7a7aea41e3b42d95e29341d6299bL28-R34)`)
  * The `compiled_code` dictionary now includes default keys (`JAXPR`, `LOWERED`, `COMPILED`) with a value of `'N/A'`. (`[src/jax_hpc_profiler/timer.pyL28-R34](diffhunk://#diff-0034a65156be75f334a9acb96d556168ecbe7a7aea41e3b42d95e29341d6299bL28-R34)`)Make default dict in init rather than in chrono_jit